### PR TITLE
Fix blog modal image hidden by overly broad CSS selector

### DIFF
--- a/assets/css/_about.css
+++ b/assets/css/_about.css
@@ -236,7 +236,7 @@
   box-shadow: var(--shadow-2)
 }
 
-.modal-img-wrapper>img {
+.testimonials-modal .modal-img-wrapper>img {
   display: none
 }
 

--- a/assets/css/_responsive.css
+++ b/assets/css/_responsive.css
@@ -222,7 +222,7 @@
     width: 65px
   }
 
-  .modal-img-wrapper>img {
+  .testimonials-modal .modal-img-wrapper>img {
     display: block;
     flex-grow: 1;
     width: 35px


### PR DESCRIPTION
.modal-img-wrapper>img { display:none } was scoped too broadly, hiding the blog modal image as well as the intended testimonials quote icon. Scoped both rules to .testimonials-modal to fix this.